### PR TITLE
fix: generate types in the packages.json

### DIFF
--- a/angular-ngc/BUILD.bazel
+++ b/angular-ngc/BUILD.bazel
@@ -6,16 +6,16 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
 
 # Libraries accessible via //:lib/{package_name}
 LIBRARIES = [
-  "common",
-  "lib-a",
+    "common",
+    "lib-a",
 ]
 
 [
-  npm_link_package(
-    name = "lib/%s" % lib,
-    src = "//libraries/%s" % lib
-  )
-  for lib in LIBRARIES
+    npm_link_package(
+        name = "lib/%s" % lib,
+        src = "//libraries/%s" % lib,
+    )
+    for lib in LIBRARIES
 ]
 
 # Link npm packages
@@ -28,6 +28,7 @@ directory_path(
     path = "bundles/src/bin/ngc.js",
     visibility = ["//visibility:private"],
 )
+
 js_binary(
     name = "ngc",
     data = ["//:node_modules/@angular/compiler-cli"],
@@ -39,5 +40,12 @@ js_binary(
 ts_config(
     name = "tsconfig",
     src = ":tsconfig.json",
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "karma.conf.js",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/angular-ngc/WORKSPACE.bazel
+++ b/angular-ngc/WORKSPACE.bazel
@@ -24,6 +24,17 @@ load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 
 rules_js_dependencies()
 
+http_archive(
+    name = "aspect_rules_esbuild",
+    sha256 = "77c414e7d82c9a66b4b6d6cb81a7a379f462215b52f5bae90faecde81798189f",
+    strip_prefix = "rules_esbuild-0.9.0",
+    url = "https://github.com/aspect-build/rules_esbuild/archive/refs/tags/v0.9.0.tar.gz",
+)
+
+load("@aspect_rules_esbuild//esbuild:dependencies.bzl", "rules_esbuild_dependencies")
+
+rules_esbuild_dependencies()
+
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(
@@ -38,12 +49,20 @@ npm_translate_lock(
     pnpm_lock = "//:pnpm-lock.yaml",
 )
 
+load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_VERSION", "esbuild_register_toolchains")
+
+esbuild_register_toolchains(
+    name = "esbuild",
+    esbuild_version = LATEST_VERSION,
+)
+
 http_archive(
     name = "aspect_rules_ts",
     sha256 = "7c89fccf94fd1452505e53376ab87a212162d0b4ef2512e1fe3fb5c5ff89c0b1",
     strip_prefix = "rules_ts-bb86a508de08ea9478aa74e39eec9ffce2f4dee2",
     url = "https://github.com/aspect-build/rules_ts/archive/bb86a508de08ea9478aa74e39eec9ffce2f4dee2.tar.gz",
 )
+
 load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_VERSION", "rules_ts_dependencies")
 
 rules_ts_dependencies(ts_version = LATEST_VERSION)

--- a/angular-ngc/defs.bzl
+++ b/angular-ngc/defs.bzl
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 
 # Common dependencies of Angular applications
 APPLICATION_DEPS = [
@@ -158,9 +159,15 @@ def ng_library(name, package_name, deps = [], test_deps = [], visibility = ["//v
                     ],
                 },
             },
-            extends = "//:tsconfig",
             testonly = 1,
+            extends = "//:tsconfig",
             visibility = ["//visibility:private"],
         )
 
-        # TODO: 'test' target
+    bundle_name = "%s_tests.bundle" % name
+    esbuild(
+        name = bundle_name,
+        testonly = 1,
+        deps = ["_%s_tests" % name],
+        entry_points = ["_%s_tests" % name],
+    )

--- a/angular-ngc/defs.bzl
+++ b/angular-ngc/defs.bzl
@@ -64,7 +64,8 @@ def ng_application(name, project_name = None, deps = [], test_deps = [], **kwarg
       test_deps: additional dependencies for tests
       **kwargs: extra args passed to main Angular CLI rules
     """
-    srcs = native.glob(["src/**/*"],
+    srcs = native.glob(
+        ["src/**/*"],
         exclude = [
             "src/**/*.spec.ts",
             "src/test.ts",
@@ -74,9 +75,8 @@ def ng_application(name, project_name = None, deps = [], test_deps = [], **kwarg
     test_srcs = native.glob(["src/test.ts", "src/**/*.spec.ts"])
 
     ng_project(
-      name = "_%s" % name
+        name = "_%s" % name,
     )
-
 
 def ng_library(name, package_name, deps = [], test_deps = [], visibility = ["//visibility:public"]):
     """
@@ -106,11 +106,11 @@ def ng_library(name, package_name, deps = [], test_deps = [], visibility = ["//v
         srcs = srcs,
         deps = deps + LIBRARY_DEPS,
         tsconfig = {
-          "compilerOptions": {
-            "declaration": True,
-            "declarationMap": True,
-            "outDir": "_dist",
-          },
+            "compilerOptions": {
+                "declaration": True,
+                "declarationMap": True,
+                "outDir": "_dist",
+            },
         },
         extends = "//:tsconfig",
         visibility = ["//visibility:private"],
@@ -118,10 +118,10 @@ def ng_library(name, package_name, deps = [], test_deps = [], visibility = ["//v
 
     # A package.json pointing to the public_api.js as the package entry point
     write_file(
-      name = "_%s_package_json" % name,
-      out = "_dist/package.json",
-      content = ["""{"name": "%s", "main": "./public_api.js"}""" % package_name],
-      visibility = ["//visibility:private"],
+        name = "_%s_package_json" % name,
+        out = "_dist/package.json",
+        content = ["""{"name": "%s", "main": "./public_api.js", "types": "./public-api.d.ts"}""" % package_name],
+        visibility = ["//visibility:private"],
     )
 
     # Output the library as an npm package that can be linked.
@@ -136,31 +136,31 @@ def ng_library(name, package_name, deps = [], test_deps = [], visibility = ["//v
     # The primary public library target. Aliased to allow "_pkg" as the npm_package()
     # name and therefore also output directory.
     native.alias(
-      name = name,
-      actual = "_pkg",
-      visibility = visibility,
+        name = name,
+        actual = "_pkg",
+        visibility = visibility,
     )
 
     test_srcs = native.glob(["src/test.ts", "src/**/*.spec.ts"])
     if len(test_srcs) > 0:
-      ng_project(
-          name = "_%s_tests" % name,
-          srcs = test_srcs,
-          deps = [":_%s" % name] + test_deps + TEST_DEPS,
-          tsconfig = {
-            "compilerOptions": {
-              "declaration": False,
-              "declarationMap": False,
-              "outDir": "_test",
-              "rootDirs": [
-                ".",
-                "_dist",
-              ],
+        ng_project(
+            name = "_%s_tests" % name,
+            srcs = test_srcs,
+            deps = [":_%s" % name] + test_deps + TEST_DEPS,
+            tsconfig = {
+                "compilerOptions": {
+                    "declaration": False,
+                    "declarationMap": False,
+                    "outDir": "_test",
+                    "rootDirs": [
+                        ".",
+                        "_dist",
+                    ],
+                },
             },
-          },
-          extends = "//:tsconfig",
-          testonly = 1,
-          visibility = ["//visibility:private"],
-      )
+            extends = "//:tsconfig",
+            testonly = 1,
+            visibility = ["//visibility:private"],
+        )
 
-      # TODO: 'test' target
+        # TODO: 'test' target


### PR DESCRIPTION
Generate `types` in the `package.json`, so `lib-a` can import `common` correctly.