### PR TITLE
refactor karma rules

### DIFF
--- a/angular-ngc/WORKSPACE.bazel
+++ b/angular-ngc/WORKSPACE.bazel
@@ -27,13 +27,9 @@ rules_js_dependencies()
 http_archive(
     name = "aspect_rules_esbuild",
     patch_args = ["-p1"],
-    remote_patch_strip = 1,
-    remote_patches = {
-        "https://patch-diff.githubusercontent.com/raw/aspect-build/rules_esbuild/pull/32.patch": "sha256-UzRzXDO9pj4kFmmpxvRHbcTrGsZ1xfxqG4RjKQmOLgo=",
-    },
-    sha256 = "77c414e7d82c9a66b4b6d6cb81a7a379f462215b52f5bae90faecde81798189f",
-    strip_prefix = "rules_esbuild-0.9.0",
-    url = "https://github.com/aspect-build/rules_esbuild/archive/refs/tags/v0.9.0.tar.gz",
+    sha256 = "edd86f968284bd787f0ae881498955a7b4078ce6a086ac9ee93eb047fb33386d",
+    strip_prefix = "rules_esbuild-70ba5c248bf2b9c8a927a249c55bb1ffb14cd37d",
+    url = "https://github.com/aspect-build/rules_esbuild/archive/70ba5c248bf2b9c8a927a249c55bb1ffb14cd37d.tar.gz",
 )
 
 load("@aspect_rules_esbuild//esbuild:dependencies.bzl", "rules_esbuild_dependencies")

--- a/angular-ngc/defs.bzl
+++ b/angular-ngc/defs.bzl
@@ -127,6 +127,7 @@ def ng_application(name, deps = [], test_deps = [], assets = None, html_assets =
         config = {
             "resolveExtensions": [".mjs", ".js"],
         },
+        metafile = False,
         format = "esm",
         minify = True,
         visibility = ["//visibility:private"],
@@ -177,6 +178,7 @@ def _pkg_web(name, entry_point, entry_deps, html_assets, assets, production, vis
         format = "esm",
         output_dir = True,
         splitting = True,
+        metafile = False,
         minify = production,
         visibility = ["//visibility:private"],
     )
@@ -211,7 +213,6 @@ def _pkg_web(name, entry_point, entry_deps, html_assets, assets, production, vis
     copy_to_directory(
         name = name,
         srcs = [":%s" % bundle, ":polyfills-bundle", ":%s" % html_out] + html_assets + assets,
-        exclude_prefixes = ["%s_metadata.json" % bundle],  #TODO: delete after https://github.com/aspect-build/rules_esbuild/commit/f3def5493814845ad1f7863dde5ba21c12f424b8
         root_paths = [".", "%s/%s" % (native.package_name(), html_out)],
         visibility = visibility,
     )
@@ -303,6 +304,7 @@ def _unit_tests(name, tests, static_files, deps, visibility):
         testonly = 1,
         entry_points = [file.replace(".ts", ".js") for file in test_srcs],
         deps = [":_test"],
+        metafile = False,
         output_dir = True,
         splitting = True,
         visibility = ["//visibility:private"],

--- a/angular-ngc/defs.bzl
+++ b/angular-ngc/defs.bzl
@@ -293,8 +293,6 @@ def _unit_tests(name, tests, static_files, deps, visibility):
         visibility = ["//visibility:private"],
     )
 
-    # TODO: move the bootstrap rules to tools so it only need to be generated once.
-    # But it will be located in different directory. We may need to use copy to directory to make it work.
     generate_test_bootstrap(
         name = "_test_bootstrap",
     )

--- a/angular-ngc/defs.bzl
+++ b/angular-ngc/defs.bzl
@@ -299,16 +299,6 @@ def _unit_tests(name, tests, static_files, deps, visibility):
         name = "_test_bootstrap",
     )
 
-    esbuild(
-        name = "_test_bootstrap_bundle",
-        testonly = 1,
-        entry_points = [":_test_bootstrap"],
-        deps = [":_test_bootstrap"],
-        output_dir = True,
-        splitting = True,
-        visibility = ["//visibility:private"],
-    )
-
     # Bundle the spec files
     ng_esbuild(
         name = "_test_bundle",
@@ -326,7 +316,7 @@ def _unit_tests(name, tests, static_files, deps, visibility):
         name = karma_config_name,
         # TODO:
         test_bundles = [":_test_bundle"],
-        bootstrap_bundles = [":_test_bootstrap_bundle"],
+        bootstrap_bundles = [":_test_bootstrap"],
         # TODO: add static_files, such as json data file consumed by a service of Angular.
         static_files = static_files,
         testonly = 1,
@@ -335,7 +325,7 @@ def _unit_tests(name, tests, static_files, deps, visibility):
     _karma_bin.karma_test(
         name = name,
         testonly = 1,
-        data = [":%s" % karma_config_name, ":_test_bundle", ":_test_bootstrap_bundle"] + TEST_RUNNER_DEPS,
+        data = [":%s" % karma_config_name, ":_test_bundle", ":_test_bootstrap"] + TEST_RUNNER_DEPS,
         args = [
             "start",
             "$(rootpath %s)" % karma_config_name,

--- a/angular-ngc/tools/BUILD.bazel
+++ b/angular-ngc/tools/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load(":ts.bzl", "ts_project")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 
 # The Angular ngc compiler
 directory_path(
@@ -34,6 +35,19 @@ ts_project(
 exports_files(
     [
         "karma.conf.js",
+        "test-setup.ts",
     ],
     visibility = ["//visibility:public"],
+)
+
+esbuild(
+    name = "prebuild_test_bootstrap",
+    testonly = 1,
+    entry_points = ["//tools:test-bootstrap.js"],
+    output_dir = True,
+    splitting = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:node_modules/zone.js",
+    ],
 )

--- a/angular-ngc/tools/BUILD.bazel
+++ b/angular-ngc/tools/BUILD.bazel
@@ -41,11 +41,9 @@ exports_files(
 )
 
 esbuild(
-    name = "prebuild_test_bootstrap",
+    name = "test_bootstrap",
     testonly = 1,
     entry_points = ["//tools:test-bootstrap.js"],
-    output_dir = True,
-    splitting = True,
     visibility = ["//visibility:public"],
     deps = [
         "//:node_modules/zone.js",

--- a/angular-ngc/tools/BUILD.bazel
+++ b/angular-ngc/tools/BUILD.bazel
@@ -43,7 +43,7 @@ exports_files(
 esbuild(
     name = "test_bootstrap",
     testonly = 1,
-    entry_point = "//tools:test-bootstrap.js",
+    entry_point = ":test-bootstrap.js",
     metafile = False,
     sourcemap = "inline",
     visibility = ["//visibility:public"],

--- a/angular-ngc/tools/BUILD.bazel
+++ b/angular-ngc/tools/BUILD.bazel
@@ -43,7 +43,9 @@ exports_files(
 esbuild(
     name = "test_bootstrap",
     testonly = 1,
-    entry_points = ["//tools:test-bootstrap.js"],
+    entry_point = "//tools:test-bootstrap.js",
+    metafile = False,
+    sourcemap = "inline",
     visibility = ["//visibility:public"],
     deps = [
         "//:node_modules/zone.js",

--- a/angular-ngc/tools/karma.bzl
+++ b/angular-ngc/tools/karma.bzl
@@ -1,5 +1,4 @@
 load(":util.bzl", "to_manifest_path")
-load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 # Generate a karma.config.js file to:
@@ -56,12 +55,11 @@ generate_karma_config = rule(
 )
 
 def generate_test_bootstrap(name):
-    copy_to_directory(
+    copy_file(
         name = name,
-        srcs = ["//tools:test_bootstrap"],
+        src = "//tools:test_bootstrap",
+        out = "test_bootstrap.js",
         testonly = 1,
-        exclude_prefixes = ["test_bootstrap_metadata.json"],  #TODO: delete after https://github.com/aspect-build/rules_esbuild/commit/f3def5493814845ad1f7863dde5ba21c12f424b8
-        root_paths = ["tools/test_bootstrap"],
     )
 
 def generate_test_setup(name):

--- a/angular-ngc/tools/karma.bzl
+++ b/angular-ngc/tools/karma.bzl
@@ -1,5 +1,6 @@
 load(":util.bzl", "to_manifest_path")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 # Generate a karma.config.js file to:
 # - run the given bundle containing specs
@@ -55,29 +56,18 @@ generate_karma_config = rule(
 )
 
 def generate_test_bootstrap(name):
-    write_file(
+    copy_to_directory(
         name = name,
-        out = "%s.js" % name,
+        srcs = ["//tools:prebuild_test_bootstrap"],
         testonly = 1,
-        content = ["import 'zone.js';", "import 'zone.js/testing';"],
+        exclude_prefixes = ["prebuild_test_bootstrap_metadata.json"],  #TODO: delete after https://github.com/aspect-build/rules_esbuild/commit/f3def5493814845ad1f7863dde5ba21c12f424b8
+        root_paths = ["tools/prebuild_test_bootstrap"],
     )
 
 def generate_test_setup(name):
-    write_file(
+    copy_file(
         name = name,
         out = "%s.ts" % name,
         testonly = 1,
-        content = [
-            "import { getTestBed } from '@angular/core/testing';",
-            "import {",
-            "  BrowserDynamicTestingModule,",
-            "  platformBrowserDynamicTesting,",
-            "} from '@angular/platform-browser-dynamic/testing';",
-            "",
-            "// First, initialize the Angular testing environment.",
-            "getTestBed().initTestEnvironment(",
-            "  BrowserDynamicTestingModule,",
-            "  platformBrowserDynamicTesting()",
-            ");",
-        ],
+        src = "//tools:test-setup.ts",
     )

--- a/angular-ngc/tools/karma.bzl
+++ b/angular-ngc/tools/karma.bzl
@@ -58,10 +58,10 @@ generate_karma_config = rule(
 def generate_test_bootstrap(name):
     copy_to_directory(
         name = name,
-        srcs = ["//tools:prebuild_test_bootstrap"],
+        srcs = ["//tools:test_bootstrap"],
         testonly = 1,
-        exclude_prefixes = ["prebuild_test_bootstrap_metadata.json"],  #TODO: delete after https://github.com/aspect-build/rules_esbuild/commit/f3def5493814845ad1f7863dde5ba21c12f424b8
-        root_paths = ["tools/prebuild_test_bootstrap"],
+        exclude_prefixes = ["test_bootstrap_metadata.json"],  #TODO: delete after https://github.com/aspect-build/rules_esbuild/commit/f3def5493814845ad1f7863dde5ba21c12f424b8
+        root_paths = ["tools/test_bootstrap"],
     )
 
 def generate_test_setup(name):

--- a/angular-ngc/tools/karma.conf.js
+++ b/angular-ngc/tools/karma.conf.js
@@ -23,9 +23,6 @@ const TEST_BUNDLE_DIRS = [
 
 const BUNDLE_FILES = [];
 TEST_BUNDLE_DIRS.forEach((dir) => {
-  if (dir.indexOf("metadata.json") !== -1) {
-    return;
-  }
   findAllFiles(__dirname + "/" + dir, BUNDLE_FILES);
 });
 

--- a/angular-ngc/tools/karma.conf.js
+++ b/angular-ngc/tools/karma.conf.js
@@ -8,21 +8,21 @@ const STATIC_FILES = [
   // END STATIC FILES
 ];
 
-const BOOTSTRAP_DIRS = [
+const TEST_BOOTSTRAP_FILES = [
   // BEGIN BOOTSTRAP FILES
   TMPL_bootstrap_files,
   // END BOOTSTRAP FILES
 ];
 
 // Test + runtime entry point files
-const BUNDLE_DIRS = [
+const TEST_BUNDLE_DIRS = [
   // BEGIN TEST SPEC FILES
   TMPL_spec_files,
   // END TEST BUNDLE FILES
 ];
 
 const BUNDLE_FILES = [];
-BUNDLE_DIRS.forEach((dir) => {
+TEST_BUNDLE_DIRS.forEach((dir) => {
   if (dir.indexOf("metadata.json") !== -1) {
     return;
   }
@@ -30,11 +30,9 @@ BUNDLE_DIRS.forEach((dir) => {
 });
 
 const BOOTSTRAP_FILES = [];
-BOOTSTRAP_DIRS.forEach((dir) => {
-  if (dir.indexOf("metadata.json") !== -1) {
-    return;
-  }
-  findAllFiles(__dirname + "/" + dir, BOOTSTRAP_FILES);
+TEST_BOOTSTRAP_FILES.forEach((file) => {
+  const filePath = __dirname + "/" + file;
+  BOOTSTRAP_FILES.push(filePath);
 });
 
 function findAllFiles(dir, found) {

--- a/angular-ngc/tools/test-bootstrap.js
+++ b/angular-ngc/tools/test-bootstrap.js
@@ -1,0 +1,2 @@
+import "zone.js";
+import "zone.js/testing";

--- a/angular-ngc/tools/test-setup.ts
+++ b/angular-ngc/tools/test-setup.ts
@@ -1,0 +1,11 @@
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/angular-ngc/tools/test-setup.ts
+++ b/angular-ngc/tools/test-setup.ts
@@ -4,7 +4,6 @@ import {
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
-// First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting()


### PR DESCRIPTION
Did refactor about the `karma` rules.
1. `test_bootstrap` will only be bundled once, and will be copied for each package.
2. Will not use `write_file` to generate `test_bootstrap` and `test_setup`, instead use file.